### PR TITLE
Add a script to sequentially scan and resync corrupted resources

### DIFF
--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -62,7 +62,7 @@ class CommandRunner(metaclass=SingletonMeta):
     def check_for_master_change(self) -> None:
         current_master = self.get_current_master()
         if self.master != current_master:
-            logger.error(f"master changed from `{self.master}` to `{current_master}`. Aborting...")
+            logger.error("master changed from `%s` to `%s`. Aborting...", self.master, current_master)
             raise SystemExit(1)
 
     def run_write_command(self, cmd: str, remote_host: str = "") -> str:
@@ -373,6 +373,6 @@ if __name__ == "__main__":
         datefmt="%b %e %H:%M:%S",
     )
 
-    CommandRunner(dry_run=args.dry_run)
+    _ = CommandRunner(dry_run=args.dry_run, ssh_key=args.key)
 
     main(include=args.include, exclude=args.exclude, print_report=args.print, verify_only=args.verify_only)

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 from functools import lru_cache
 
-from typing import Any, Dict, Iterator, List, Optional, Set, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, cast
 
 SCRIPT_NAME = "drbd-resync"
 DRBD_CMD_STATUS = "drbdsetup status all --json"
@@ -20,6 +20,8 @@ DRBD_CMD_INVALIDATE_REMOTE = (
 )
 
 logger = logging.getLogger(__name__)
+
+JSON = Dict[str, Any]
 
 
 def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
@@ -75,7 +77,7 @@ class Host:
     def __hash__(self) -> int:
         return hash(self.hostname)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> JSON:
         return self.__dict__
 
 class LinstorPeer(Host):
@@ -114,7 +116,7 @@ class ResourceKey:
     def __hash__(self) -> int:
         return hash((self.name, self.peer))
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> JSON:
         return self.__dict__
 
 
@@ -144,12 +146,8 @@ class ResourceStatus(ResourceKey):
     def __str__(self) -> str:
         return f"{self.key},{self.out_of_sync}"
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> JSON:
         return self.__dict__
-
-
-JSON = Dict[str, Any]
-StatusUnion = Union[List[ResourceStatus], Iterator[ResourceStatus]]
 
 
 def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
@@ -162,11 +160,11 @@ def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
     return None
 
 
-def get_bad_resources_from_status(
+def get_resources_from_status(
     status: List[JSON],
     oos_only: bool = False,
     resource_name: str = "",
-) -> StatusUnion:
+) -> Iterator[ResourceStatus]:
     return (
         ResourceStatus(
             name=resource.get("name", ""),
@@ -200,12 +198,12 @@ def get_status(remote_host: str = "") -> List[JSON]:
     )
 
 
-def get_oos_statuses(
+def get_resources(
     oos_only: bool = False,
     resource_name: str = "",
     remote_host: str = "",
-) -> StatusUnion:
-    return get_bad_resources_from_status(
+) -> Iterator[ResourceStatus]:
+    return get_resources_from_status(
         get_status(remote_host),
         oos_only=oos_only,
         resource_name=resource_name,
@@ -255,12 +253,10 @@ def main(
     for host in hosts:
         remote_host = host.ip if host.ip != host.from_host.ip else ""
 
-        for status in list(get_oos_statuses(resource_name=resource_name, remote_host=remote_host)):
+        for status in list(get_resources(resource_name=resource_name, remote_host=remote_host)):
             drbd_verify_resource(status, remote_host=remote_host)
 
-        resources = get_oos_statuses(oos_only=True, resource_name=resource_name, remote_host=remote_host)
-
-        for resource in resources:
+        for resource in get_resources(oos_only=True, resource_name=resource_name, remote_host=remote_host):
             logging.info(
                 "resource `%s` on `%s` is out of sync by %s",
                 resource.name, resource.peer.hostname, resource.out_of_sync

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -6,6 +6,7 @@ import logging
 import os
 import shlex
 import subprocess
+from collections import Counter
 from functools import lru_cache
 
 from typing import Any, Dict, Iterator, List, Optional, Set, cast
@@ -306,16 +307,15 @@ def main(
 
     for resource_name, resources in all_resources.items():
         msg = f"{resource_name} is reported out-of-sync by:"
-        counts: Dict[ResourceStatus, int] = {}
-        for resource in resources:
-            counts[resource] = counts.get(resource, 0) + 1
+        counts = Counter(resources)
+        for resource, count in counts.items():
             msg += "\n\t{} on {} by {}".format(
                 resource.peer.from_host.hostname, resource.peer.hostname, resource.out_of_sync
             )
         logger.info(msg)
 
-        max_count = max(counts.values())
-        top_resources = [s for s, c in counts.items() if c == max_count]
+        max_count = counts.most_common(1)[0][1]  # [(resource, count)]
+        top_resources = [r for r, c in counts.most_common() if c == max_count]
 
         # Each host will check which peer's resource has different values,
         #  admitting 2 hosts with a sane resource and 1 with corrupted data:

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import logging
@@ -8,7 +10,7 @@ from functools import lru_cache
 
 from typing import Any, Dict, Iterator, List, Optional, Set, Union, cast
 
-SCRIPT_NAME = "drbd_resource_repair"
+SCRIPT_NAME = "drbd-resync"
 DRBD_CMD_STATUS = "drbdsetup status all --json"
 DRBD_CMD_VERIFY = "drbdadm verify {resource_name}:{peer}/0"
 DRBD_CMD_WAIT_SYNC = "drbdadm wait-sync {resource_name}"

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -8,47 +8,77 @@ import shlex
 import subprocess
 from functools import lru_cache
 
-from typing import Any, Dict, Iterator, List, Optional, Set, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, cast
 
 SCRIPT_NAME = "drbd-resync"
+XE_CMD_POOL_MASTER = "xe pool-list params=master --minimal"
 DRBD_CMD_STATUS = "drbdsetup status all --json"
 DRBD_CMD_VERIFY = "drbdadm verify {resource_name}:{peer}/0"
 DRBD_CMD_WAIT_SYNC = "drbdadm wait-sync {resource_name}"
 DRBD_CMD_INVALIDATE = "drbdadm invalidate {resource_name}:{peer}/0 --reset-bitmap=no"
-DRBD_CMD_INVALIDATE_REMOTE = (
-    "drbdadm invalidate-remote {resource_name}:{peer}/0 --reset-bitmap=no"
-)
+DRBD_CMD_INVALIDATE_REMOTE = "drbdadm invalidate-remote {resource_name}:{peer}/0 --reset-bitmap=no"
 
 logger = logging.getLogger(__name__)
 
 JSON = Dict[str, Any]
 
 
-def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
-    if remote_host:
-        cmd = f"ssh root@{remote_host} -C {cmd}"
-    logger.debug(cmd)
-    if DRY_RUN and not ignore_dry_run:
-        return ""
-    try:
-        return subprocess.run(
-            shlex.split(cmd),
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-        ).stdout.strip()
-    except subprocess.CalledProcessError as e:
-        logger.error("%s failed with error code %d: `%s`", cmd, e.returncode, e.output)
-        raise e
+class SingletonMeta(type):
+    _instances: Dict[type, Any] = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(SingletonMeta, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class CommandRunner(metaclass=SingletonMeta):
+    def __init__(self, dry_run: bool = False):
+        self.dry_run = dry_run
+        self.master = self.get_current_master()
+
+    def run_command(self, cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
+        if remote_host:
+            cmd = f"ssh root@{shlex.quote(remote_host)} -C {shlex.quote(cmd)}"
+        logger.debug(cmd)
+        if self.dry_run and not ignore_dry_run:
+            return ""
+        try:
+            return subprocess.run(
+                shlex.split(cmd),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+            ).stdout.strip()
+        except subprocess.CalledProcessError as e:
+            logger.error("%s failed with error code %d: `%s`", cmd, e.returncode, e.output)
+            raise
+
+    def get_current_master(self) -> str:
+        return self.run_command(XE_CMD_POOL_MASTER, ignore_dry_run=True)
+
+    def check_for_master_change(self) -> None:
+        current_master = self.get_current_master()
+        if self.master != current_master:
+            logger.error(f"master changed from `{self.master}` to `{current_master}`. Aborting...")
+            raise SystemExit(1)
+
+    def run_write_command(self, cmd: str, remote_host: str = "") -> str:
+        self.check_for_master_change()
+        return self.run_command(cmd, ignore_dry_run=False, remote_host=remote_host)
+
+    def run_read_command(self, cmd: str, remote_host: str = "") -> str:
+        self.check_for_master_change()
+        return self.run_command(cmd, ignore_dry_run=True, remote_host=remote_host)
 
 
 def run_write_command(cmd: str, remote_host: str = "") -> str:
-    return run_command(cmd, ignore_dry_run=False, remote_host=remote_host)
+    return CommandRunner().run_write_command(cmd, remote_host=remote_host)
 
 
 def run_read_command(cmd: str, remote_host: str = "") -> str:
-    return run_command(cmd, ignore_dry_run=True, remote_host=remote_host)
+    return CommandRunner().run_read_command(cmd, remote_host=remote_host)
 
 
 # FIXME Change to @cache when upgrading to python>=3.9
@@ -69,16 +99,14 @@ class Host:
         return ",".join([self.hostname, self.ip])
 
     def __eq__(self, other: Any) -> bool:
-        return (
-            isinstance(other, Host)
-            and self.hostname == other.hostname
-        )
+        return isinstance(other, Host) and self.hostname == other.hostname
 
     def __hash__(self) -> int:
         return hash(self.hostname)
 
     def to_json(self) -> JSON:
-        return self.__dict__
+        return {"ip": self.ip, "hostname": self.hostname}
+
 
 class LinstorPeer(Host):
     def __init__(self, ip: str, from_ip: str):
@@ -90,6 +118,14 @@ class LinstorPeer(Host):
 
     # Intentionally not overloading eq and hash since the from_host
     #  does not change the peer
+
+    def to_json(self) -> JSON:
+        return {
+            "ip": self.ip,
+            "hostname": self.hostname,
+            "from_host": self.from_host.to_json(),
+        }
+
 
 class ResourceKey:
     """Represents the identifying pair of a resource's name and peer hostname.
@@ -106,18 +142,14 @@ class ResourceKey:
     def __str__(self) -> str:
         return f"{self.name}:{self.peer}"
 
-    def __eq__(self, other):
-        return (
-            isinstance(other, ResourceKey)
-            and self.name == other.name
-            and self.peer == other.peer
-        )
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, ResourceKey) and self.name == other.name and self.peer == other.peer
 
     def __hash__(self) -> int:
         return hash((self.name, self.peer))
 
     def to_json(self) -> JSON:
-        return self.__dict__
+        return {"name": self.name, "peer": self.peer.to_json()}
 
 
 class ResourceStatus(ResourceKey):
@@ -147,7 +179,11 @@ class ResourceStatus(ResourceKey):
         return f"{self.key},{self.out_of_sync}"
 
     def to_json(self) -> JSON:
-        return self.__dict__
+        return {
+            "name": self.name,
+            "peer": self.peer.to_json(),
+            "out_of_sync": self.out_of_sync,
+        }
 
 
 def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
@@ -163,8 +199,8 @@ def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
 def get_resources_from_status(
     status: List[JSON],
     oos_only: bool = False,
-    include: Union[List[str], None] = None,
-    exclude: Union[List[str], None] = None
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
 ) -> Iterator[ResourceStatus]:
     return (
         ResourceStatus(
@@ -195,23 +231,20 @@ def get_peers_from_status(status: List[JSON]) -> Set[LinstorPeer]:
 
 
 def get_status(remote_host: str = "") -> List[JSON]:
-    return json.loads(
-        run_read_command(DRBD_CMD_STATUS, remote_host=remote_host)
-    )
+    try:
+        return json.loads(run_read_command(DRBD_CMD_STATUS, remote_host=remote_host))
+    except json.JSONDecodeError as e:
+        logger.error("Failed to parse status: %s", e)
+        raise SystemExit(1)
 
 
 def get_resources(
     oos_only: bool = False,
-    include: Union[List[str], None] = None,
-    exclude: Union[List[str], None] = None,
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
     remote_host: str = "",
 ) -> Iterator[ResourceStatus]:
-    return get_resources_from_status(
-        get_status(remote_host),
-        oos_only=oos_only,
-        include=include,
-        exclude=exclude
-    )
+    return get_resources_from_status(get_status(remote_host), oos_only=oos_only, include=include, exclude=exclude)
 
 
 def drbd_verify_resource(resource: ResourceStatus, remote_host: str = "") -> None:
@@ -225,9 +258,7 @@ def drbd_verify_resource(resource: ResourceStatus, remote_host: str = "") -> Non
     )
 
 
-def drbd_resync_resource(
-    resource: ResourceStatus, local: bool = False, remote_host: str = ""
-) -> None:
+def drbd_resync_resource(resource: ResourceStatus, local: bool = False, remote_host: str = "") -> None:
     cmd = DRBD_CMD_INVALIDATE if local else DRBD_CMD_INVALIDATE_REMOTE
     run_write_command(
         cmd.format(resource_name=resource.name, peer=resource.peer.hostname),
@@ -241,16 +272,19 @@ def drbd_resync_resource(
 
 def get_all_peers() -> Set[LinstorPeer]:
     hosts = get_peers_from_status(get_status())
+    if not hosts:
+        logger.error("No peers found")
+        raise SystemExit(1)
     local_ip = next(iter(hosts)).from_host.ip
     hosts.add(LinstorPeer(local_ip, local_ip))
     return hosts
 
 
 def main(
-    include: Union[List[str], None] = None,
-    exclude: Union[List[str], None] = None,
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
     print_report: bool = False,
-    verify_only: bool = False
+    verify_only: bool = False,
 ) -> None:
     hosts = get_all_peers()
     all_resources: Dict[str, List[ResourceStatus]] = {}
@@ -262,9 +296,11 @@ def main(
             drbd_verify_resource(resource, remote_host=remote_host)
 
         for resource in get_resources(oos_only=True, include=include, exclude=exclude, remote_host=remote_host):
-            logging.info(
+            logger.info(
                 "resource `%s` on `%s` is out of sync by %s",
-                resource.name, resource.peer.hostname, resource.out_of_sync
+                resource.name,
+                resource.peer.hostname,
+                resource.out_of_sync,
             )
             all_resources.setdefault(resource.name, []).append(resource)
 
@@ -299,10 +335,7 @@ def main(
             continue
 
         top_resource = top_resources[0]
-        logger.info(
-            "Designed %s as the host with the corrupted %s",
-            top_resource.peer.hostname, top_resource.name
-        )
+        logger.info("Designated %s as the host with the corrupted %s", top_resource.peer.hostname, top_resource.name)
         reports.append(top_resource)
 
         if verify_only:
@@ -313,20 +346,17 @@ def main(
     if print_report:
         print(json.dumps(reports, default=lambda o: o.to_json()))
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--verify-only", action="store_true")
     parser.add_argument("--print", action="store_true")
     parser.add_argument(
-        "--include",
-        action="append",
-        help="resource prefix to include. Can be specified multiple times"
+        "--include", action="append", help="resource prefix to include. Can be specified multiple times"
     )
     parser.add_argument(
-        "--exclude",
-        action="append",
-        help="resource prefix to exclude. Can be specified multiple times"
+        "--exclude", action="append", help="resource prefix to exclude. Can be specified multiple times"
     )
     parser.add_argument(
         "--log-level",
@@ -336,16 +366,13 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    DRY_RUN = args.dry_run
 
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), None),
         format=f"%(asctime)s {SCRIPT_NAME}: [{os.getpid()}] %(levelname)-8s %(message)s",
-        datefmt="%b %e %H:%M:%S"
+        datefmt="%b %e %H:%M:%S",
     )
-    main(
-        include=args.include,
-        exclude=args.exclude,
-        print_report=args.print,
-        verify_only=args.verify_only
-    )
+
+    CommandRunner(dry_run=args.dry_run)
+
+    main(include=args.include, exclude=args.exclude, print_report=args.print, verify_only=args.verify_only)

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 from functools import lru_cache
 
-from typing import Any, Dict, Iterator, List, Optional, Set, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, Union, cast
 
 SCRIPT_NAME = "drbd-resync"
 DRBD_CMD_STATUS = "drbdsetup status all --json"
@@ -163,7 +163,8 @@ def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
 def get_resources_from_status(
     status: List[JSON],
     oos_only: bool = False,
-    resource_name: str = "",
+    include: Union[List[str], None] = None,
+    exclude: Union[List[str], None] = None
 ) -> Iterator[ResourceStatus]:
     return (
         ResourceStatus(
@@ -176,7 +177,8 @@ def get_resources_from_status(
         for peer_device in connection.get("peer_devices", [])
         if (
             (not oos_only or peer_device.get("out-of-sync", 0) > 0)
-            and (not resource_name or resource.get("name", "") == resource_name)
+            and (not include or any(resource.get("name", "").startswith(p) for p in include))
+            and (not exclude or all(not resource.get("name", "").startswith(p) for p in exclude))
             and get_peer_from_connection(connection)
         )
     )
@@ -200,13 +202,15 @@ def get_status(remote_host: str = "") -> List[JSON]:
 
 def get_resources(
     oos_only: bool = False,
-    resource_name: str = "",
+    include: Union[List[str], None] = None,
+    exclude: Union[List[str], None] = None,
     remote_host: str = "",
 ) -> Iterator[ResourceStatus]:
     return get_resources_from_status(
         get_status(remote_host),
         oos_only=oos_only,
-        resource_name=resource_name,
+        include=include,
+        exclude=exclude
     )
 
 
@@ -243,7 +247,8 @@ def get_all_peers() -> Set[LinstorPeer]:
 
 
 def main(
-    resource_name: str = "",
+    include: Union[List[str], None] = None,
+    exclude: Union[List[str], None] = None,
     print_report: bool = False,
     verify_only: bool = False
 ) -> None:
@@ -253,10 +258,10 @@ def main(
     for host in hosts:
         remote_host = host.ip if host.ip != host.from_host.ip else ""
 
-        for status in list(get_resources(resource_name=resource_name, remote_host=remote_host)):
-            drbd_verify_resource(status, remote_host=remote_host)
+        for resource in list(get_resources(include=include, exclude=exclude, remote_host=remote_host)):
+            drbd_verify_resource(resource, remote_host=remote_host)
 
-        for resource in get_resources(oos_only=True, resource_name=resource_name, remote_host=remote_host):
+        for resource in get_resources(oos_only=True, include=include, exclude=exclude, remote_host=remote_host):
             logging.info(
                 "resource `%s` on `%s` is out of sync by %s",
                 resource.name, resource.peer.hostname, resource.out_of_sync
@@ -313,7 +318,16 @@ if __name__ == "__main__":
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--verify-only", action="store_true")
     parser.add_argument("--print", action="store_true")
-    parser.add_argument("--resource", type=str)
+    parser.add_argument(
+        "--include",
+        action="append",
+        help="resource prefix to include. Can be specified multiple times"
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        help="resource prefix to exclude. Can be specified multiple times"
+    )
     parser.add_argument(
         "--log-level",
         type=lambda x: x.upper(),
@@ -330,7 +344,8 @@ if __name__ == "__main__":
         datefmt="%b %e %H:%M:%S"
     )
     main(
-        resource_name=args.resource,
+        include=args.include,
+        exclude=args.exclude,
         print_report=args.print,
         verify_only=args.verify_only
     )

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -34,13 +34,15 @@ class SingletonMeta(type):
 
 
 class CommandRunner(metaclass=SingletonMeta):
-    def __init__(self, dry_run: bool = False):
+    def __init__(self, dry_run: bool = False, ssh_key: Optional[str] = None):
         self.dry_run = dry_run
+        self.ssh_key = ssh_key
         self.master = self.get_current_master()
 
     def run_command(self, cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
+        with_key = f" -i {shlex.quote(self.ssh_key)}" if self.ssh_key else ""
         if remote_host:
-            cmd = f"ssh root@{shlex.quote(remote_host)} -C {shlex.quote(cmd)}"
+            cmd = f"ssh root@{shlex.quote(remote_host)}{with_key} -C {shlex.quote(cmd)}"
         logger.debug(cmd)
         if self.dry_run and not ignore_dry_run:
             return ""
@@ -285,6 +287,7 @@ def main(
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
     print_report: bool = False,
+    output_file: str = "stdout",
     verify_only: bool = False,
 ) -> None:
     hosts = get_all_peers()
@@ -344,7 +347,15 @@ def main(
         drbd_resync_resource(top_resource, remote_host=top_resource.peer.from_host.ip)
 
     if print_report:
-        print(json.dumps(reports, default=lambda o: o.to_json()))
+        report = json.dumps(reports, default=lambda o: o.to_json())
+        if output_file == "stdout":
+            print(report)
+            return
+        dir_path = os.path.dirname(output_file)
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path, exist_ok=True)
+        with open(output_file, 'w') as f:
+            f.write(report)
 
 
 if __name__ == "__main__":
@@ -352,12 +363,15 @@ if __name__ == "__main__":
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--verify-only", action="store_true")
     parser.add_argument("--print", action="store_true")
+    parser.add_argument("--service", action="store_true")
     parser.add_argument(
         "--include", action="append", help="resource prefix to include. Can be specified multiple times"
     )
     parser.add_argument(
         "--exclude", action="append", help="resource prefix to exclude. Can be specified multiple times"
     )
+    parser.add_argument("--output", help="output file to use with --print", default="stdout")
+    parser.add_argument("--key", help="ssh key to use for connection to peers")
     parser.add_argument(
         "--log-level",
         type=lambda x: x.upper(),
@@ -367,12 +381,19 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    log_format = "%(levelname)-8s %(message)s"
+    if not args.service:
+        log_format = f"%(asctime)s {SCRIPT_NAME}: [{os.getpid()}] {log_format}"
     logging.basicConfig(
-        level=getattr(logging, args.log_level.upper(), None),
-        format=f"%(asctime)s {SCRIPT_NAME}: [{os.getpid()}] %(levelname)-8s %(message)s",
-        datefmt="%b %e %H:%M:%S",
+        level=getattr(logging, args.log_level.upper(), None), format=log_format, datefmt="%b %e %H:%M:%S"
     )
 
     _ = CommandRunner(dry_run=args.dry_run, ssh_key=args.key)
 
-    main(include=args.include, exclude=args.exclude, print_report=args.print, verify_only=args.verify_only)
+    main(
+        include=args.include,
+        exclude=args.exclude,
+        print_report=args.print,
+        output_file=args.output,
+        verify_only=args.verify_only,
+    )

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -12,7 +12,7 @@ from functools import lru_cache
 from typing import Any, Dict, Iterator, List, Optional, Set, cast
 
 SCRIPT_NAME = "drbd-resync"
-XE_CMD_POOL_MASTER = "xe pool-list params=master --minimal"
+XE_CMD_POOL_MASTER = "cat /etc/xensource/pool.conf"
 DRBD_CMD_STATUS = "drbdsetup status all --json"
 DRBD_CMD_VERIFY = "drbdadm verify {resource_name}:{peer}/0"
 DRBD_CMD_WAIT_SYNC = "drbdadm wait-sync {resource_name}"
@@ -59,7 +59,11 @@ class CommandRunner(metaclass=SingletonMeta):
             raise
 
     def get_current_master(self) -> str:
-        return self.run_command(XE_CMD_POOL_MASTER, ignore_dry_run=True)
+        master = self.run_command(XE_CMD_POOL_MASTER, ignore_dry_run=True)
+        if "slave" not in master and "master" not in master:
+            logger.error("Failed to determine current master in output: `%s`", master)
+            raise SystemExit(1)
+        return master
 
     def check_for_master_change(self) -> None:
         current_master = self.get_current_master()

--- a/sources/drbd-resync
+++ b/sources/drbd-resync
@@ -89,7 +89,14 @@ class LinstorPeer(Host):
     # Intentionally not overloading eq and hash since the from_host
     #  does not change the peer
 
-class ResourceStatusKey:
+class ResourceKey:
+    """Represents the identifying pair of a resource's name and peer hostname.
+
+    Attributes:
+        name (str): The resource's name.
+        peer (LinstorPeer): The peer on which the resource instance resides.
+    """
+
     def __init__(self, name: str, peer: LinstorPeer):
         self.name = name
         self.peer = peer
@@ -99,7 +106,7 @@ class ResourceStatusKey:
 
     def __eq__(self, other):
         return (
-            isinstance(other, ResourceStatusKey)
+            isinstance(other, ResourceKey)
             and self.name == other.name
             and self.peer == other.peer
         )
@@ -111,7 +118,21 @@ class ResourceStatusKey:
         return self.__dict__
 
 
-class ResourceStatus(ResourceStatusKey):
+class ResourceStatus(ResourceKey):
+    """Represents a resource along with its synchronization status.
+
+    Extends:
+        ResourceKey
+
+    Attributes:
+        out_of_sync (int): Amount of data out of sync, in kilobytes (KB).
+            This value represents the replication lag between the different nodes.
+            It is gathered from LINSTOR's reported 'out-of-sync' metric.
+
+    Properties:
+        key (str): A string representation of the resource key (``name:peer``).
+    """
+
     def __init__(self, name: str, peer: LinstorPeer, out_of_sync: int):
         super().__init__(name, peer)
         self.out_of_sync = out_of_sync
@@ -259,6 +280,15 @@ def main(
         max_count = max(counts.values())
         top_resources = [s for s, c in counts.items() if c == max_count]
 
+        # Each host will check which peer's resource has different values,
+        #  admitting 2 hosts with a sane resource and 1 with corrupted data:
+        #  The corrupted one will report each as out-of-sync,
+        #  while the sane ones will report the corrupted one as out-of-sync;
+        #  this will result in 2 reports for the corrupted one
+        #  and one report for each sane host. We can infer from this that the one with
+        #  the most reports is the corrupted one.
+        #  In the event of a tie, it's safer to leave it to human decision
+        #  since which is which can't be inferred.
         if len(top_resources) > 1:
             logger.error(
                 "Tie detected: multiple hosts with highest reports (%d): %s. Skipping.",

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -156,7 +156,7 @@ def get_status(remote_host: str = "") -> List[JSON]:
     )
 
 
-def get_oos_status(
+def get_oos_statuses(
     lazy: bool = False,
     oos_only: bool = False,
     resource: str = "",
@@ -209,29 +209,27 @@ def main(
     reports: List[ResourceStatus] = []
     for host in hosts:
         remote_host = host.ip if host.ip != host.from_host.ip else ""
-        statuses = get_oos_status(lazy=True, resource=resource, remote_host=remote_host)
+        statuses = get_oos_statuses(lazy=True, resource=resource, remote_host=remote_host)
 
-        for s in statuses:
-            verify_resource(s, remote_host=remote_host)
+        for status in statuses:
+            verify_resource(status, remote_host=remote_host)
 
-        statuses = get_oos_status(
-            lazy=False, oos_only=True, resource=resource, remote_host=remote_host
-        )
+        statuses = get_oos_statuses(lazy=False, oos_only=True, resource=resource, remote_host=remote_host)
 
-        for s in statuses:
+        for status in statuses:
             logging.info(
                 "resource `%s` on `%s` is out of sync by %s",
-                s.resource, s.peer.hostname, s.out_of_sync
+                status.resource, status.peer.hostname, status.out_of_sync
             )
-            all_statuses.setdefault(s.resource, []).append(s)
+            all_statuses.setdefault(status.resource, []).append(status)
 
-    for resource_name, status_list in all_statuses.items():
+    for resource_name, statuses in all_statuses.items():
         msg = f"{resource} is reported out-of-sync by:"
         counts: Dict[ResourceStatus, int] = {}
-        for s in status_list:
-            counts[s] = counts.get(s, 0) + 1
+        for status in statuses:
+            counts[status] = counts.get(status, 0) + 1
             msg += "\n\t{} on {} by {}".format(
-                s.peer.from_host.hostname, s.peer.hostname, s.out_of_sync
+                status.peer.from_host.hostname, status.peer.hostname, status.out_of_sync
             )
         logger.info(msg)
 

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -4,7 +4,6 @@ import logging
 import os
 import shlex
 import subprocess
-import sys
 from functools import lru_cache
 
 from typing import Any, Dict, Iterator, List, Optional, Set, Union
@@ -278,11 +277,10 @@ if __name__ == "__main__":
     args = parser.parse_args()
     DRY_RUN = args.dry_run
 
-    script_name = os.path.basename(sys.argv[0])
     pid = os.getpid()
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), None),
-        format=f"%(asctime)s {script_name}: [{pid}] %(levelname)-8s %(message)s",
+        format=f"%(asctime)s {SCRIPT_NAME}: [{pid}] %(levelname)-8s %(message)s",
         datefmt="%b %e %H:%M:%S"
     )
     logger = logging.getLogger(__name__)

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -37,7 +37,7 @@ def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -
         raise e
 
 
-@lru_cache()
+@cache()
 def get_hostname(ip: str) -> str:
     return run_command("hostname", ignore_dry_run=True, remote_host=ip)
 
@@ -188,7 +188,10 @@ def drbd_resync_resource(
         cmd.format(resource=status.resource, peer=status.peer.hostname),
         remote_host=remote_host,
     )
-    run_command(DRBD_WAIT_SYNC.format(resource=status.resource,))
+    run_command(
+        DRBD_WAIT_SYNC.format(resource=status.resource),
+        remote_host=remote_host,
+    )
 
 
 def get_all_hosts() -> Set[LinstorPeer]:

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -169,7 +169,7 @@ def get_oos_statuses(
     )
 
 
-def verify_resource(status: ResourceStatus, remote_host: str = "") -> None:
+def drbd_verify_resource(status: ResourceStatus, remote_host: str = "") -> None:
     run_command(
         DRBD_VERIFY.format(resource=status.resource, peer=status.peer.hostname),
         remote_host=remote_host,
@@ -180,7 +180,7 @@ def verify_resource(status: ResourceStatus, remote_host: str = "") -> None:
     )
 
 
-def resync_resource(
+def drbd_resync_resource(
     status: ResourceStatus, local: bool = False, remote_host: str = ""
 ) -> None:
     cmd = DRBD_INVALIDATE if local else DRBD_INVALIDATE_REMOTE
@@ -211,7 +211,7 @@ def main(
         statuses = get_oos_statuses(lazy=True, resource=resource, remote_host=remote_host)
 
         for status in statuses:
-            verify_resource(status, remote_host=remote_host)
+            drbd_verify_resource(status, remote_host=remote_host)
 
         statuses = get_oos_statuses(lazy=False, oos_only=True, resource=resource, remote_host=remote_host)
 
@@ -253,10 +253,7 @@ def main(
         if verify_only:
             continue
 
-        resync_resource(
-            top_resource,
-            remote_host=top_resource.peer.from_host.ip,
-        )
+        drbd_resync_resource(top_resource, remote_host=top_resource.peer.from_host.ip)
 
     if print_report:
         print(json.dumps(reports, default=lambda o: o.to_json()))

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -6,16 +6,18 @@ import shlex
 import subprocess
 from functools import lru_cache
 
-from typing import Any, Dict, Iterator, List, Optional, Set, Union
+from typing import Any, Dict, Iterator, List, Optional, Set, Union, cast
 
 SCRIPT_NAME = "drbd_resource_repair"
-DRBD_STATUS = "drbdsetup status all --json"
-DRBD_VERIFY = "drbdadm verify {resource}:{peer}/0"
-DRBD_WAIT_SYNC = "drbdadm wait-sync {resource}"
-DRBD_INVALIDATE = "drbdadm invalidate {resource}:{peer}/0 --reset-bitmap=no"
-DRBD_INVALIDATE_REMOTE = (
-    "drbdadm invalidate-remote {resource}:{peer}/0 --reset-bitmap=no"
+DRBD_CMD_STATUS = "drbdsetup status all --json"
+DRBD_CMD_VERIFY = "drbdadm verify {resource_name}:{peer}/0"
+DRBD_CMD_WAIT_SYNC = "drbdadm wait-sync {resource_name}"
+DRBD_CMD_INVALIDATE = "drbdadm invalidate {resource_name}:{peer}/0 --reset-bitmap=no"
+DRBD_CMD_INVALIDATE_REMOTE = (
+    "drbdadm invalidate-remote {resource_name}:{peer}/0 --reset-bitmap=no"
 )
+
+logger = logging.getLogger(__name__)
 
 
 def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
@@ -37,9 +39,18 @@ def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -
         raise e
 
 
-@cache()
+def run_write_command(cmd: str, remote_host: str = "") -> str:
+    return run_command(cmd, ignore_dry_run=False, remote_host=remote_host)
+
+
+def run_read_command(cmd: str, remote_host: str = "") -> str:
+    return run_command(cmd, ignore_dry_run=True, remote_host=remote_host)
+
+
+# FIXME Change to @cache when upgrading to python>=3.9
+@lru_cache()
 def get_hostname(ip: str) -> str:
-    return run_command("hostname", ignore_dry_run=True, remote_host=ip)
+    return run_read_command("hostname", remote_host=ip)
 
 
 class Host:
@@ -56,12 +67,11 @@ class Host:
     def __eq__(self, other: Any) -> bool:
         return (
             isinstance(other, Host)
-            and self.ip == other.ip
             and self.hostname == other.hostname
         )
 
     def __hash__(self) -> int:
-        return hash((self.ip, self.hostname))
+        return hash(self.hostname)
 
     def to_json(self) -> Dict[str, Any]:
         return self.__dict__
@@ -77,29 +87,43 @@ class LinstorPeer(Host):
     # Intentionally not overloading eq and hash since the from_host
     #  does not change the peer
 
-
-class ResourceStatus:
-    def __init__(self, resource: str, peer: LinstorPeer, out_of_sync: int):
-        self.resource = resource
+class ResourceStatusKey:
+    def __init__(self, name: str, peer: LinstorPeer):
+        self.name = name
         self.peer = peer
-        self.out_of_sync = out_of_sync
 
     def __str__(self) -> str:
-        return ",".join([self.resource, str(self.peer), str(self.out_of_sync)])
+        return f"{self.name}:{self.peer}"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other):
         return (
-            isinstance(other, ResourceStatus)
-            and self.resource == other.resource
+            isinstance(other, ResourceStatusKey)
+            and self.name == other.name
             and self.peer == other.peer
-            and self.out_of_sync == other.out_of_sync
         )
 
     def __hash__(self) -> int:
-        return hash((self.resource, self.peer, self.out_of_sync))
+        return hash((self.name, self.peer))
 
     def to_json(self) -> Dict[str, Any]:
         return self.__dict__
+
+
+class ResourceStatus(ResourceStatusKey):
+    def __init__(self, name: str, peer: LinstorPeer, out_of_sync: int):
+        super().__init__(name, peer)
+        self.out_of_sync = out_of_sync
+
+    @property
+    def key(self) -> str:
+        return super().__str__()
+
+    def __str__(self) -> str:
+        return f"{self.key},{self.out_of_sync}"
+
+    def to_json(self) -> Dict[str, Any]:
+        return self.__dict__
+
 
 JSON = Dict[str, Any]
 StatusUnion = Union[List[ResourceStatus], Iterator[ResourceStatus]]
@@ -117,14 +141,13 @@ def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
 
 def get_bad_resources_from_status(
     status: List[JSON],
-    lazy: bool = False,
     oos_only: bool = False,
     resource_name: str = "",
 ) -> StatusUnion:
-    statuses = (
+    return (
         ResourceStatus(
-            resource=resource.get("name", ""),
-            peer=get_peer_from_connection(connection),  # type: ignore
+            name=resource.get("name", ""),
+            peer=cast(LinstorPeer, get_peer_from_connection(connection)),
             out_of_sync=peer_device.get("out-of-sync", 0),
         )
         for resource in status
@@ -136,7 +159,6 @@ def get_bad_resources_from_status(
             and get_peer_from_connection(connection)
         )
     )
-    return statuses if lazy else list(statuses)
 
 
 def get_peers_from_status(status: List[JSON]) -> Set[LinstorPeer]:
@@ -151,50 +173,48 @@ def get_peers_from_status(status: List[JSON]) -> Set[LinstorPeer]:
 
 def get_status(remote_host: str = "") -> List[JSON]:
     return json.loads(
-        run_command(DRBD_STATUS, ignore_dry_run=True, remote_host=remote_host)
+        run_read_command(DRBD_CMD_STATUS, remote_host=remote_host)
     )
 
 
 def get_oos_statuses(
-    lazy: bool = False,
     oos_only: bool = False,
-    resource: str = "",
+    resource_name: str = "",
     remote_host: str = "",
 ) -> StatusUnion:
     return get_bad_resources_from_status(
         get_status(remote_host),
-        lazy=lazy,
         oos_only=oos_only,
-        resource_name=resource,
+        resource_name=resource_name,
     )
 
 
-def drbd_verify_resource(status: ResourceStatus, remote_host: str = "") -> None:
-    run_command(
-        DRBD_VERIFY.format(resource=status.resource, peer=status.peer.hostname),
+def drbd_verify_resource(resource: ResourceStatus, remote_host: str = "") -> None:
+    run_write_command(
+        DRBD_CMD_VERIFY.format(resource_name=resource.name, peer=resource.peer.hostname),
         remote_host=remote_host,
     )
-    run_command(
-        DRBD_WAIT_SYNC.format(resource=status.resource),
+    run_read_command(
+        DRBD_CMD_WAIT_SYNC.format(resource_name=resource.name),
         remote_host=remote_host,
     )
 
 
 def drbd_resync_resource(
-    status: ResourceStatus, local: bool = False, remote_host: str = ""
+    resource: ResourceStatus, local: bool = False, remote_host: str = ""
 ) -> None:
-    cmd = DRBD_INVALIDATE if local else DRBD_INVALIDATE_REMOTE
-    run_command(
-        cmd.format(resource=status.resource, peer=status.peer.hostname),
+    cmd = DRBD_CMD_INVALIDATE if local else DRBD_CMD_INVALIDATE_REMOTE
+    run_write_command(
+        cmd.format(resource_name=resource.name, peer=resource.peer.hostname),
         remote_host=remote_host,
     )
-    run_command(
-        DRBD_WAIT_SYNC.format(resource=status.resource),
+    run_read_command(
+        DRBD_CMD_WAIT_SYNC.format(resource_name=resource.name),
         remote_host=remote_host,
     )
 
 
-def get_all_hosts() -> Set[LinstorPeer]:
+def get_all_peers() -> Set[LinstorPeer]:
     hosts = get_peers_from_status(get_status())
     local_ip = next(iter(hosts)).from_host.ip
     hosts.add(LinstorPeer(local_ip, local_ip))
@@ -202,36 +222,35 @@ def get_all_hosts() -> Set[LinstorPeer]:
 
 
 def main(
-    resource: str = "",
+    resource_name: str = "",
     print_report: bool = False,
     verify_only: bool = False
 ) -> None:
-    hosts = get_all_hosts()
-    all_statuses: Dict[str, List[ResourceStatus]] = {}
+    hosts = get_all_peers()
+    all_resources: Dict[str, List[ResourceStatus]] = {}
     reports: List[ResourceStatus] = []
     for host in hosts:
         remote_host = host.ip if host.ip != host.from_host.ip else ""
-        statuses = get_oos_statuses(lazy=True, resource=resource, remote_host=remote_host)
 
-        for status in statuses:
+        for status in list(get_oos_statuses(resource_name=resource_name, remote_host=remote_host)):
             drbd_verify_resource(status, remote_host=remote_host)
 
-        statuses = get_oos_statuses(lazy=False, oos_only=True, resource=resource, remote_host=remote_host)
+        resources = get_oos_statuses(oos_only=True, resource_name=resource_name, remote_host=remote_host)
 
-        for status in statuses:
+        for resource in resources:
             logging.info(
                 "resource `%s` on `%s` is out of sync by %s",
-                status.resource, status.peer.hostname, status.out_of_sync
+                resource.name, resource.peer.hostname, resource.out_of_sync
             )
-            all_statuses.setdefault(status.resource, []).append(status)
+            all_resources.setdefault(resource.name, []).append(resource)
 
-    for resource_name, statuses in all_statuses.items():
-        msg = f"{resource} is reported out-of-sync by:"
+    for resource_name, resources in all_resources.items():
+        msg = f"{resource_name} is reported out-of-sync by:"
         counts: Dict[ResourceStatus, int] = {}
-        for status in statuses:
-            counts[status] = counts.get(status, 0) + 1
+        for resource in resources:
+            counts[resource] = counts.get(resource, 0) + 1
             msg += "\n\t{} on {} by {}".format(
-                status.peer.from_host.hostname, status.peer.hostname, status.out_of_sync
+                resource.peer.from_host.hostname, resource.peer.hostname, resource.out_of_sync
             )
         logger.info(msg)
 
@@ -249,7 +268,7 @@ def main(
         top_resource = top_resources[0]
         logger.info(
             "Designed %s as the host with the corrupted %s",
-            top_resource.peer.hostname, top_resource.resource
+            top_resource.peer.hostname, top_resource.name
         )
         reports.append(top_resource)
 
@@ -277,16 +296,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     DRY_RUN = args.dry_run
 
-    pid = os.getpid()
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), None),
-        format=f"%(asctime)s {SCRIPT_NAME}: [{pid}] %(levelname)-8s %(message)s",
+        format=f"%(asctime)s {SCRIPT_NAME}: [{os.getpid()}] %(levelname)-8s %(message)s",
         datefmt="%b %e %H:%M:%S"
     )
-    logger = logging.getLogger(__name__)
-
     main(
-        resource=args.resource,
+        resource_name=args.resource,
         print_report=args.print,
-        verify_only = args.verify_only
+        verify_only=args.verify_only
     )

--- a/sources/drbd_resource_repair.py
+++ b/sources/drbd_resource_repair.py
@@ -1,0 +1,296 @@
+import argparse
+import json
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from functools import lru_cache
+
+from typing import Any, Dict, Iterator, List, Optional, Set, Union
+
+SCRIPT_NAME = "drbd_resource_repair"
+DRBD_STATUS = "drbdsetup status all --json"
+DRBD_VERIFY = "drbdadm verify {resource}:{peer}/0"
+DRBD_WAIT_SYNC = "drbdadm wait-sync {resource}"
+DRBD_INVALIDATE = "drbdadm invalidate {resource}:{peer}/0 --reset-bitmap=no"
+DRBD_INVALIDATE_REMOTE = (
+    "drbdadm invalidate-remote {resource}:{peer}/0 --reset-bitmap=no"
+)
+
+
+def run_command(cmd: str, ignore_dry_run: bool = False, remote_host: str = "") -> str:
+    if remote_host:
+        cmd = f"ssh root@{remote_host} -C {cmd}"
+    logger.debug(cmd)
+    if DRY_RUN and not ignore_dry_run:
+        return ""
+    try:
+        return subprocess.run(
+            shlex.split(cmd),
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as e:
+        logger.error("%s failed with error code %d: `%s`", cmd, e.returncode, e.output)
+        raise e
+
+
+@lru_cache()
+def get_hostname(ip: str) -> str:
+    return run_command("hostname", ignore_dry_run=True, remote_host=ip)
+
+
+class Host:
+    def __init__(self, ip: str):
+        self.ip = ip
+
+    @property
+    def hostname(self) -> str:
+        return get_hostname(self.ip)
+
+    def __str__(self) -> str:
+        return ",".join([self.hostname, self.ip])
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, Host)
+            and self.ip == other.ip
+            and self.hostname == other.hostname
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.ip, self.hostname))
+
+    def to_json(self) -> Dict[str, Any]:
+        return self.__dict__
+
+class LinstorPeer(Host):
+    def __init__(self, ip: str, from_ip: str):
+        super().__init__(ip)
+        self.from_host = Host(from_ip)
+
+    def __str__(self) -> str:
+        return ",".join([super().__str__(), str(self.from_host)])
+
+    # Intentionally not overloading eq and hash since the from_host
+    #  does not change the peer
+
+
+class ResourceStatus:
+    def __init__(self, resource: str, peer: LinstorPeer, out_of_sync: int):
+        self.resource = resource
+        self.peer = peer
+        self.out_of_sync = out_of_sync
+
+    def __str__(self) -> str:
+        return ",".join([self.resource, str(self.peer), str(self.out_of_sync)])
+
+    def __eq__(self, other: Any) -> bool:
+        return (
+            isinstance(other, ResourceStatus)
+            and self.resource == other.resource
+            and self.peer == other.peer
+            and self.out_of_sync == other.out_of_sync
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.resource, self.peer, self.out_of_sync))
+
+    def to_json(self) -> Dict[str, Any]:
+        return self.__dict__
+
+JSON = Dict[str, Any]
+StatusUnion = Union[List[ResourceStatus], Iterator[ResourceStatus]]
+
+
+def get_peer_from_connection(connection: JSON) -> Optional[LinstorPeer]:
+    for path in connection.get("paths", []):
+        if path.get("established"):
+            remote = path.get("remote_host", {}).get("address")
+            local = path.get("this_host", {}).get("address")
+            if remote and local:
+                return LinstorPeer(remote, local)
+    return None
+
+
+def get_bad_resources_from_status(
+    status: List[JSON],
+    lazy: bool = False,
+    oos_only: bool = False,
+    resource_name: str = "",
+) -> StatusUnion:
+    statuses = (
+        ResourceStatus(
+            resource=resource.get("name", ""),
+            peer=get_peer_from_connection(connection),  # type: ignore
+            out_of_sync=peer_device.get("out-of-sync", 0),
+        )
+        for resource in status
+        for connection in resource.get("connections", [])
+        for peer_device in connection.get("peer_devices", [])
+        if (
+            (not oos_only or peer_device.get("out-of-sync", 0) > 0)
+            and (not resource_name or resource.get("name", "") == resource_name)
+            and get_peer_from_connection(connection)
+        )
+    )
+    return statuses if lazy else list(statuses)
+
+
+def get_peers_from_status(status: List[JSON]) -> Set[LinstorPeer]:
+    peers = set()
+    for resource in status:
+        for connection in resource.get("connections", []):
+            peer = get_peer_from_connection(connection)
+            if peer:
+                peers.add(peer)
+    return peers
+
+
+def get_status(remote_host: str = "") -> List[JSON]:
+    return json.loads(
+        run_command(DRBD_STATUS, ignore_dry_run=True, remote_host=remote_host)
+    )
+
+
+def get_oos_status(
+    lazy: bool = False,
+    oos_only: bool = False,
+    resource: str = "",
+    remote_host: str = "",
+) -> StatusUnion:
+    return get_bad_resources_from_status(
+        get_status(remote_host),
+        lazy=lazy,
+        oos_only=oos_only,
+        resource_name=resource,
+    )
+
+
+def verify_resource(status: ResourceStatus, remote_host: str = "") -> None:
+    run_command(
+        DRBD_VERIFY.format(resource=status.resource, peer=status.peer.hostname),
+        remote_host=remote_host,
+    )
+    run_command(
+        DRBD_WAIT_SYNC.format(resource=status.resource),
+        remote_host=remote_host,
+    )
+
+
+def resync_resource(
+    status: ResourceStatus, local: bool = False, remote_host: str = ""
+) -> None:
+    cmd = DRBD_INVALIDATE if local else DRBD_INVALIDATE_REMOTE
+    run_command(
+        cmd.format(resource=status.resource, peer=status.peer.hostname),
+        remote_host=remote_host,
+    )
+    run_command(DRBD_WAIT_SYNC.format(resource=status.resource,))
+
+
+def get_all_hosts() -> Set[LinstorPeer]:
+    hosts = get_peers_from_status(get_status())
+    local_ip = next(iter(hosts)).from_host.ip
+    hosts.add(LinstorPeer(local_ip, local_ip))
+    return hosts
+
+
+def main(
+    resource: str = "",
+    print_report: bool = False,
+    verify_only: bool = False
+) -> None:
+    hosts = get_all_hosts()
+    all_statuses: Dict[str, List[ResourceStatus]] = {}
+    reports: List[ResourceStatus] = []
+    for host in hosts:
+        remote_host = host.ip if host.ip != host.from_host.ip else ""
+        statuses = get_oos_status(lazy=True, resource=resource, remote_host=remote_host)
+
+        for s in statuses:
+            verify_resource(s, remote_host=remote_host)
+
+        statuses = get_oos_status(
+            lazy=False, oos_only=True, resource=resource, remote_host=remote_host
+        )
+
+        for s in statuses:
+            logging.info(
+                "resource `%s` on `%s` is out of sync by %s",
+                s.resource, s.peer.hostname, s.out_of_sync
+            )
+            all_statuses.setdefault(s.resource, []).append(s)
+
+    for resource_name, status_list in all_statuses.items():
+        msg = f"{resource} is reported out-of-sync by:"
+        counts: Dict[ResourceStatus, int] = {}
+        for s in status_list:
+            counts[s] = counts.get(s, 0) + 1
+            msg += "\n\t{} on {} by {}".format(
+                s.peer.from_host.hostname, s.peer.hostname, s.out_of_sync
+            )
+        logger.info(msg)
+
+        max_count = max(counts.values())
+        top_resources = [s for s, c in counts.items() if c == max_count]
+
+        if len(top_resources) > 1:
+            logger.error(
+                "Tie detected: multiple hosts with highest reports (%d): %s. Skipping.",
+                max_count,
+                ", ".join([s.peer.hostname for s in top_resources]),
+            )
+            continue
+
+        top_resource = top_resources[0]
+        logger.info(
+            "Designed %s as the host with the corrupted %s",
+            top_resource.peer.hostname, top_resource.resource
+        )
+        reports.append(top_resource)
+
+        if verify_only:
+            continue
+
+        resync_resource(
+            top_resource,
+            remote_host=top_resource.peer.from_host.ip,
+        )
+
+    if print_report:
+        print(json.dumps(reports, default=lambda o: o.to_json()))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--print", action="store_true")
+    parser.add_argument("--resource", type=str)
+    parser.add_argument(
+        "--log-level",
+        type=lambda x: x.upper(),
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+    )
+
+    args = parser.parse_args()
+    DRY_RUN = args.dry_run
+
+    script_name = os.path.basename(sys.argv[0])
+    pid = os.getpid()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), None),
+        format=f"%(asctime)s {script_name}: [{pid}] %(levelname)-8s %(message)s",
+        datefmt="%b %e %H:%M:%S"
+    )
+    logger = logging.getLogger(__name__)
+
+    main(
+        resource=args.resource,
+        print_report=args.print,
+        verify_only = args.verify_only
+    )


### PR DESCRIPTION
Scans sequentially using drbdadm verify on each host and elects a "corrupted" host based on the reports. The resource is then resync-ed with drbdadm invalidate-remote.