### PR TITLE
feat(drbd-resync): add systemd service and timers

### DIFF
--- a/configs/drbd-resync-persistent.timer
+++ b/configs/drbd-resync-persistent.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=10 minute timer for drbd-resync on LINSTOR persistent volumes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=10min
+Unit=drbd-resync@xcp-persistent.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/drbd-resync-volume.timer
+++ b/configs/drbd-resync-volume.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=10 minute timer for drbd-resync on LINSTOR volumes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=10min
+Unit=drbd-resync@xcp-volume.service
+
+[Install]
+WantedBy=timers.target

--- a/configs/drbd-resync@.service
+++ b/configs/drbd-resync@.service
@@ -13,7 +13,6 @@ After=linstor-satellite.service
 
 
 [Service]
-Type=oneshot
 Restart=no
 RemainAfterExit=no
 
@@ -26,4 +25,4 @@ SyslogFacility=daemon
 EnvironmentFile=-/etc/default/drbd-resync
 
 # Additional flags may be added via DRBD_RESYNC_EXTRA_ARGS
-ExecStart=/opt/xensource/bin/drbd-resync --log-level DEBUG --service --print --output /run/drbd-resync/%I.json --include "%i" $DRBD_RESYNC_EXTRA_ARGS
+ExecStart=/opt/xensource/bin/drbd-resync --service --print --output /run/drbd-resync/%I.json --include "%i" $DRBD_RESYNC_EXTRA_ARGS

--- a/configs/drbd-resync@.service
+++ b/configs/drbd-resync@.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=DRBD Resync script for resources prefixed by %I
+
+DefaultDependencies=no
+
+Requires=xapi-init-complete.target
+Requires=drbd-reactor.service
+Requires=linstor-satellite.service
+
+After=xapi-init-complete.target
+After=drbd-reactor.service
+After=linstor-satellite.service
+
+
+[Service]
+Type=oneshot
+Restart=no
+RemainAfterExit=no
+
+StandardOutput=file:/var/log/drbd-resync.log
+StandardError=syslog
+SyslogIdentifier=drbd-resync
+SyslogFacility=daemon
+
+# Environment file for extra args
+EnvironmentFile=-/etc/default/drbd-resync
+
+# Additional flags may be added via DRBD_RESYNC_EXTRA_ARGS
+ExecStart=/opt/xensource/bin/drbd-resync --log-level DEBUG --service --print --output /run/drbd-resync/%I.json --include "%i" $DRBD_RESYNC_EXTRA_ARGS

--- a/configs/drbd-resync@.timer
+++ b/configs/drbd-resync@.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=10 minute timer for drbd-resync on %I
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=10min
+Unit=drbd-resync@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Add a template service file to be used as an interface for other processes.

The service is oneshot, logs in daemon.log and outputs in `/run/drbd-resync/%I.json` where `%I` is the template argument corresponding to the resource prefix to include. 
It can take additional arguments from the environment variable `DRBD_RESYNC_EXTRA_ARGS` read from `/etc/default/drbd-resync`.

⚠️ Target branch is to be changed once the script is merged ⚠️ 